### PR TITLE
Support embargoed Dandisets

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Before running `backups2datalad`, the following setup must be performed:
   version 10.20230126 is required, though you should endeavor to obtain the
   latest version.
 
+- An API token needs to be obtained for the DANDI instance that is being
+  mirrored.  When invoking `backups2datalad`, the environment variable
+  `DANDI_API_KEY` must be set to the token.
+
 - A configuration file should be written.  This is a YAML file containing a
   mapping with the following keys:
 
@@ -175,6 +179,9 @@ Usage
 Run `backups2datalad` with:
 
     backups2datalad --config path/to/config/file <subcommand> ...
+
+The environment variable `DANDI_API_KEY` must be set to an API token for the
+DANDI instance being mirrored.
 
 Run `backups2datalad --help` for details on the global options and summaries of
 the subcommands.

--- a/README.md
+++ b/README.md
@@ -208,6 +208,9 @@ the subcommands.
 
 - `zarr-checksum` — Computes the Zarr checksum for a given Zarr mirror
 
+- `register-s3urls` — Ensure that all blob assets in the backup of the given
+  Dandiset have their S3 URLs registered with git-annex
+
 Run `backups2datalad <subcommand> --help` for further details on each
 subcommand.
 

--- a/src/backups2datalad/__main__.py
+++ b/src/backups2datalad/__main__.py
@@ -5,6 +5,7 @@ from contextlib import aclosing
 from functools import partial, wraps
 import json
 import logging
+import os
 from pathlib import Path
 import re
 import shlex
@@ -79,8 +80,13 @@ async def main(
         cfg.backup_root = backup_root
     if jobs is not None:
         cfg.jobs = jobs
+    api_token = os.environ.get("DANDI_API_KEY", "").strip()
+    if api_token == "":
+        raise click.UsageError("DANDI_API_KEY environment variable not set")
     ctx.obj = DandiDatasetter(
-        dandi_client=AsyncDandiClient.for_dandi_instance(cfg.dandi_instance),
+        dandi_client=AsyncDandiClient.for_dandi_instance(
+            cfg.dandi_instance, token=api_token
+        ),
         config=cfg,
     )
     if pdb:

--- a/src/backups2datalad/__main__.py
+++ b/src/backups2datalad/__main__.py
@@ -23,6 +23,7 @@ from .config import BackupConfig, Mode, ZarrMode
 from .consts import GIT_OPTIONS
 from .datasetter import DandiDatasetter
 from .logging import log
+from .register_s3 import register_s3urls
 from .util import format_errors, pdb_excepthook, quantify
 
 
@@ -487,6 +488,27 @@ async def zarr_checksum(dirpath: Path) -> None:
     """
     ds = AsyncDataset(dirpath)
     print(await ds.compute_zarr_checksum())
+
+
+@main.command("register-s3urls")
+@click.argument("dandiset_id")
+@click.pass_obj
+@print_logfile
+async def register_s3urls_cmd(datasetter: DandiDatasetter, dandiset_id: str) -> None:
+    """
+    Ensure that all blob assets in the backup of the given Dandiset have their
+    S3 URLs registered with git-annex.
+
+    This command should only be necessary if something went wrong when
+    processing the unembargoing of a Dandiset.
+    """
+    async with datasetter:
+        p = datasetter.config.dandiset_root / dandiset_id
+        ds = AsyncDataset(p)
+        if not ds.ds.is_installed():
+            raise click.UsageError(f"Dataset at {p} not installed")
+        d = await datasetter.dandi_client.get_dandiset(dandiset_id, "draft")
+        await register_s3urls(manager=datasetter.manager, dandiset=d, ds=ds)
 
 
 async def populate(

--- a/src/backups2datalad/adandi.py
+++ b/src/backups2datalad/adandi.py
@@ -118,11 +118,15 @@ class AsyncDandiClient(AsyncResource):
             yield RemoteDandiset.from_data(self, data)
 
     async def create_dandiset(
-        self, name: str, metadata: dict[str, Any]
+        self, name: str, metadata: dict[str, Any], embargo: bool = False
     ) -> RemoteDandiset:
         return RemoteDandiset.from_data(
             self,
-            await self.post("/dandisets/", json={"name": name, "metadata": metadata}),
+            await self.post(
+                "/dandisets/",
+                json={"name": name, "metadata": metadata},
+                params={"embargo": str(embargo).lower()},
+            ),
         )
 
 

--- a/src/backups2datalad/adandi.py
+++ b/src/backups2datalad/adandi.py
@@ -104,7 +104,9 @@ class AsyncDandiClient(AsyncResource):
 
     async def get_dandisets(self) -> AsyncGenerator[RemoteDandiset, None]:
         # Unlike the synchronous method, this always uses the draft version
-        async with aclosing(self.paginate("/dandisets/")) as ait:
+        async with aclosing(
+            self.paginate("/dandisets/", params={"embargoed": "true"})
+        ) as ait:
             async for data in ait:
                 yield RemoteDandiset.from_data(self, data)
 

--- a/src/backups2datalad/adataset.py
+++ b/src/backups2datalad/adataset.py
@@ -156,7 +156,6 @@ class AsyncDataset:
             ".datalad/config",
             "--replace-all",
             EMBARGO_STATUS_KEY,
-            "--",
             status.value,
         )
 

--- a/src/backups2datalad/adataset.py
+++ b/src/backups2datalad/adataset.py
@@ -396,6 +396,9 @@ class AsyncDataset:
         log.debug("Computed Zarr checksum %s for %s", checksum, self.pathobj)
         return checksum
 
+    async def has_github_remote(self) -> bool:
+        return "github" in (await self.read_git("remote")).splitlines()
+
     async def create_github_sibling(
         self,
         owner: str,
@@ -405,7 +408,7 @@ class AsyncDataset:
         existing: str = "reconfigure",
     ) -> bool:
         # Returns True iff sibling was created
-        if "github" not in (await self.read_git("remote")).splitlines():
+        if not await self.has_github_remote():
             log.info("Creating GitHub sibling for %s", name)
             private = await self.get_embargo_status() is EmbargoStatus.EMBARGOED
             await anyio.to_thread.run_sync(

--- a/src/backups2datalad/adataset.py
+++ b/src/backups2datalad/adataset.py
@@ -513,6 +513,10 @@ class AsyncDataset:
     async def get_commit_hash(self) -> str:
         return await self.read_git("show", "-s", "--format=%H")
 
+    async def get_last_commit_date(self) -> datetime:
+        ts = await self.read_git("show", "-s", "--format=%aI")
+        return datetime.fromisoformat(ts)
+
     def assert_no_duplicates_in_gitmodules(self) -> None:
         filepath = self.pathobj / ".gitmodules"
         if not filepath.exists():

--- a/src/backups2datalad/asyncer.py
+++ b/src/backups2datalad/asyncer.py
@@ -48,7 +48,6 @@ from .zarr import ZarrLink, sync_zarr
 class ToDownload:
     blob: BlobBackup
     url: str
-    extra_urls: list[str]
 
 
 @dataclass
@@ -314,19 +313,12 @@ class Downloader:
                     )
                 else:
                     await self.ensure_addurl()
-                    if self.embargoed:
-                        url = blob.asset.base_download_url
-                        extra_urls = []
-                    else:
-                        url = await blob.get_file_bucket_url(self.s3client)
-                        extra_urls = [blob.asset.base_download_url]
+                    url = blob.asset.base_download_url
                     blob.log.info(
                         "File is text; sending off for download from %s",
                         url,
                     )
-                    await sender.send(
-                        ToDownload(blob=blob, url=url, extra_urls=extra_urls)
-                    )
+                    await sender.send(ToDownload(blob=blob, url=url))
 
     async def process_zarr(
         self, asset: RemoteZarrAsset, zarr_digest: str | None

--- a/src/backups2datalad/asyncer.py
+++ b/src/backups2datalad/asyncer.py
@@ -13,7 +13,6 @@ import os.path
 from pathlib import Path, PurePosixPath
 import subprocess
 from types import TracebackType
-from urllib.parse import urlparse, urlunparse
 
 import anyio
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
@@ -24,12 +23,12 @@ from dandischema.models import DigestType
 import datalad
 from datalad.api import clone
 import httpx
-from identify.identify import tags_from_filename
 
-from .adandi import RemoteAsset, RemoteDandiset, RemoteZarrAsset
+from .adandi import RemoteAsset, RemoteBlobAsset, RemoteDandiset, RemoteZarrAsset
 from .adataset import AssetsState, AsyncDataset
-from .aioutil import TextProcess, arequest, aruncmd, open_git_annex
+from .aioutil import TextProcess, aruncmd, open_git_annex
 from .annex import AsyncAnnex
+from .blob import BlobBackup
 from .config import BackupConfig, ZarrMode
 from .consts import GIT_OPTIONS, USER_AGENT
 from .logging import PrefixedLogger, log
@@ -47,10 +46,9 @@ from .zarr import ZarrLink, sync_zarr
 
 @dataclass
 class ToDownload:
-    path: str
+    blob: BlobBackup
     url: str
     extra_urls: list[str]
-    sha256_digest: str
 
 
 @dataclass
@@ -194,6 +192,7 @@ class Downloader:
                                 name=f"process_zarr:{asset.path}",
                             )
                     else:
+                        assert isinstance(asset, RemoteBlobAsset)
                         try:
                             sha256_digest = asset.get_digest_value(DigestType.sha2_256)
                             assert sha256_digest is not None
@@ -205,12 +204,18 @@ class Downloader:
                             )
                             downloading = False
                         else:
+                            blob = BlobBackup(
+                                asset=asset,
+                                sha256_digest=sha256_digest,
+                                manager=self.manager.with_sublogger(
+                                    f"Asset {asset.path}"
+                                ),
+                            )
                             self.nursery.start_soon(
-                                self.process_asset,
-                                asset,
-                                sha256_digest,
+                                self.process_blob,
+                                blob,
                                 self.download_sender.clone(),
-                                name=f"process_asset:{asset.path}",
+                                name=f"process_blob:{asset.path}",
                             )
                 # Not `else`, as we want to "fall through" if `downloading`
                 # is negated above.
@@ -231,107 +236,96 @@ class Downloader:
                             )
                             self.report.old_unhashed += 1
 
-    async def process_asset(
+    async def process_blob(
         self,
-        asset: RemoteAsset,
-        sha256_digest: str,
+        blob: BlobBackup,
         sender: MemoryObjectSendStream[ToDownload],
     ) -> None:
         async with sender:
-            self.last_timestamp = maxdatetime(self.last_timestamp, asset.created)
-            dest = self.repo / asset.path
-            if not self.tracker.register_asset(asset, force=self.config.force):
-                self.log.debug(
-                    "%s: metadata unchanged; not taking any further action",
-                    asset.path,
-                )
-                self.tracker.finish_asset(asset.path)
+            self.last_timestamp = maxdatetime(self.last_timestamp, blob.asset.created)
+            dest = self.repo / blob.path
+            if not self.tracker.register_asset(blob.asset, force=self.config.force):
+                blob.log.debug("metadata unchanged; not taking any further action")
+                self.tracker.finish_asset(blob.path)
                 return
-            if not self.config.match_asset(asset.path):
-                self.log.debug("%s: Skipping asset", asset.path)
-                self.tracker.finish_asset(asset.path)
+            if not self.config.match_asset(blob.path):
+                blob.log.debug("Skipping asset")
+                self.tracker.finish_asset(blob.path)
                 return
             if self.error_on_change:
                 raise UnexpectedChangeError(
                     f"Dandiset {self.dandiset_id}: Metadata for asset"
-                    f" {asset.path} was changed/added but draft timestamp was"
+                    f" {blob.path} was changed/added but draft timestamp was"
                     " not updated on server"
                 )
-            self.log.info("%s: Syncing", asset.path)
+            blob.log.info("Syncing")
             dest.parent.mkdir(parents=True, exist_ok=True)
             to_update = False
             if not (dest.exists() or dest.is_symlink()):
-                self.log.info("%s: Not in dataset; will add", asset.path)
+                blob.log.info("Not in dataset; will add")
                 to_update = True
                 self.report.added += 1
             else:
-                self.log.debug("%s: About to fetch hash from annex", asset.path)
-                if sha256_digest == await self.get_annex_hash(dest):
-                    self.log.info(
-                        "%s: Asset in dataset, and hash shows no modification;"
+                blob.log.debug("About to fetch hash from annex")
+                if blob.sha256_digest == await self.get_annex_hash(dest):
+                    blob.log.info(
+                        "Asset in dataset, and hash shows no modification;"
                         " will not update",
-                        asset.path,
                     )
-                    self.tracker.finish_asset(asset.path)
+                    self.tracker.finish_asset(blob.path)
                 else:
-                    self.log.info(
-                        "%s: Asset in dataset, and hash shows modification;"
-                        " will update",
-                        asset.path,
+                    blob.log.info(
+                        "Asset in dataset, and hash shows modification; will update",
                     )
                     to_update = True
                     self.report.updated += 1
             if to_update:
-                bucket_url = await self.get_file_bucket_url(asset)
-                await self.ds.remove(asset.path)
-                if "text" not in tags_from_filename(asset.path):
-                    self.log.info(
-                        "%s: File is binary; registering key with git-annex", asset.path
-                    )
+                await self.ds.remove(blob.path)
+                if blob.is_binary():
+                    blob.log.info("File is binary; registering key with git-annex")
                     key = await self.annex.mkkey(
-                        PurePosixPath(asset.path).name, asset.size, sha256_digest
+                        PurePosixPath(blob.path).name,
+                        blob.asset.size,
+                        blob.sha256_digest,
                     )
-                    await self.annex.from_key(key, asset.path)
+                    await self.annex.from_key(key, blob.path)
                     if not self.embargoed:
-                        await self.register_url(asset.path, key, bucket_url)
-                    await self.register_url(asset.path, key, asset.base_download_url)
+                        bucket_url = await blob.get_file_bucket_url(self.s3client)
+                        await blob.register_url(self.annex, key, bucket_url)
+                    await blob.register_url(
+                        self.annex, key, blob.asset.base_download_url
+                    )
                     remotes = await self.annex.get_key_remotes(key)
                     if (
                         remotes is not None
                         and self.config.dandisets.remote is not None
                         and self.config.dandisets.remote.name not in remotes
                     ):
-                        self.log.info(
-                            "%s: Not in backup remote %r",
-                            asset.path,
+                        blob.log.info(
+                            "Not in backup remote %r",
                             self.config.dandisets.remote.name,
                         )
-                    self.tracker.finish_asset(asset.path)
+                    self.tracker.finish_asset(blob.path)
                     self.report.registered += 1
-                elif asset.size > (10 << 20):
+                elif blob.asset.size > (10 << 20):
                     raise RuntimeError(
-                        f"{asset.path} identified as text but is {asset.size} bytes!"
+                        f"{blob.path} identified as text but is"
+                        f" {blob.asset.size} bytes!"
                     )
                 else:
-                    self.log.info(
-                        "%s: File is text; sending off for download from %s",
-                        asset.path,
-                        bucket_url,
-                    )
                     await self.ensure_addurl()
                     if self.embargoed:
-                        url = asset.base_download_url
+                        url = blob.asset.base_download_url
                         extra_urls = []
                     else:
-                        url = bucket_url
-                        extra_urls = [asset.base_download_url]
+                        url = await blob.get_file_bucket_url(self.s3client)
+                        extra_urls = [blob.asset.base_download_url]
+                    blob.log.info(
+                        "File is text; sending off for download from %s",
+                        url,
+                    )
                     await sender.send(
-                        ToDownload(
-                            path=asset.path,
-                            url=url,
-                            extra_urls=extra_urls,
-                            sha256_digest=sha256_digest,
-                        )
+                        ToDownload(blob=blob, url=url, extra_urls=extra_urls)
                     )
 
     async def process_zarr(
@@ -373,22 +367,6 @@ class Downloader:
                 self.manager.with_sublogger(f"Zarr {asset.zarr}"),
             )
             self.zarrs[asset.zarr] = zl
-
-    async def get_file_bucket_url(self, asset: RemoteAsset) -> str:
-        self.log.debug("%s: Fetching bucket URL", asset.path)
-        aws_url = asset.get_content_url(self.config.content_url_regex)
-        urlbits = urlparse(aws_url)
-        key = urlbits.path.lstrip("/")
-        self.log.debug("%s: About to query S3", asset.path)
-        r = await arequest(
-            self.s3client,
-            "HEAD",
-            f"https://{self.config.s3bucket}.s3.amazonaws.com/{key}",
-        )
-        r.raise_for_status()
-        version_id = r.headers["x-amz-version-id"]
-        self.log.debug("%s: Got bucket URL", asset.path)
-        return urlunparse(urlbits._replace(query=f"versionId={version_id}"))
 
     async def get_annex_hash(self, filepath: Path) -> str:
         # OPT: do not bother checking or talking to annex --
@@ -434,9 +412,9 @@ class Downloader:
                         # Lock dataset while there are any downloads in
                         # progress in order to prevent conflicts with `git rm`.
                         await self.ds.lock.acquire()
-                    self.in_progress[td.path] = td
-                    self.log.info("%s: Downloading from %s", td.path, td.url)
-                    await self.addurl.send(f"{td.url} {td.path}\n")
+                    self.in_progress[td.blob.path] = td
+                    td.blob.log.info("Downloading from %s", td.url)
+                    await self.addurl.send(f"{td.url} {td.blob.path}\n")
                 self.log.debug("Done feeding URLs to addurl")
 
     def pop_in_progress(self, path: str) -> ToDownload:
@@ -475,26 +453,20 @@ class Downloader:
                 self.log.info("%s: Finished downloading (key = %s)", path, key)
                 self.report.downloaded += 1
                 dl = self.pop_in_progress(path)
-                self.tracker.finish_asset(dl.path)
+                self.tracker.finish_asset(dl.blob.path)
                 self.nursery.start_soon(
                     self.check_unannexed_hash,
-                    dl.path,
-                    dl.sha256_digest,
-                    name=f"check_unannexed_hash:{dl.path}",
+                    dl.blob,
+                    name=f"check_unannexed_hash:{dl.blob.path}",
                 )
         self.log.debug("Done reading from addurl")
 
-    async def register_url(self, path: str, key: str, url: str) -> None:
-        self.log.info("%s: Registering URL %s", path, url)
-        await self.annex.register_url(key, url)
-
-    async def check_unannexed_hash(self, asset_path: str, sha256_digest: str) -> None:
-        annex_hash = await self.asha256(self.repo / asset_path)
-        if sha256_digest != annex_hash:
-            self.log.error(
-                "%s: Hash mismatch!  Dandiarchive reports %s, local file has %s",
-                asset_path,
-                sha256_digest,
+    async def check_unannexed_hash(self, blob: BlobBackup) -> None:
+        annex_hash = await self.asha256(self.repo / blob.path)
+        if blob.sha256_digest != annex_hash:
+            blob.log.error(
+                "Hash mismatch!  Dandiarchive reports %s, local file has %s",
+                blob.sha256_digest,
                 annex_hash,
             )
             self.report.hash_mismatches += 1

--- a/src/backups2datalad/blob.py
+++ b/src/backups2datalad/blob.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlparse, urlunparse
+
+import httpx
+from identify.identify import tags_from_filename
+
+from .adandi import RemoteBlobAsset
+from .aioutil import arequest
+from .annex import AsyncAnnex
+from .config import BackupConfig
+from .logging import PrefixedLogger
+from .manager import Manager
+
+
+@dataclass
+class BlobBackup:
+    asset: RemoteBlobAsset
+    sha256_digest: str
+    manager: Manager
+
+    @property
+    def path(self) -> str:
+        return self.asset.path
+
+    @property
+    def config(self) -> BackupConfig:
+        return self.manager.config
+
+    @property
+    def log(self) -> PrefixedLogger:
+        return self.manager.log
+
+    def is_binary(self) -> bool:
+        return "text" not in tags_from_filename(self.path)
+
+    async def get_file_bucket_url(self, s3client: httpx.AsyncClient) -> str:
+        self.log.debug("Fetching bucket URL")
+        aws_url = self.asset.get_content_url(self.config.content_url_regex)
+        urlbits = urlparse(aws_url)
+        key = urlbits.path.lstrip("/")
+        self.log.debug("About to query S3")
+        r = await arequest(
+            s3client,
+            "HEAD",
+            f"https://{self.config.s3bucket}.s3.amazonaws.com/{key}",
+        )
+        r.raise_for_status()
+        version_id = r.headers["x-amz-version-id"]
+        self.log.debug("Got bucket URL")
+        return urlunparse(urlbits._replace(query=f"versionId={version_id}"))
+
+    async def register_url(self, annex: AsyncAnnex, key: str, url: str) -> None:
+        self.log.info("Registering URL %s", url)
+        await annex.register_url(key, url)

--- a/src/backups2datalad/register_s3.py
+++ b/src/backups2datalad/register_s3.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from contextlib import aclosing
+
+from dandi.exceptions import NotFoundError
+from dandischema.models import DigestType
+import httpx
+
+from .adandi import RemoteBlobAsset, RemoteDandiset
+from .adataset import AsyncDataset
+from .annex import AsyncAnnex
+from .blob import BlobBackup
+from .consts import USER_AGENT
+from .manager import Manager
+from .util import key2hash
+
+
+async def register_s3urls(
+    manager: Manager, dandiset: RemoteDandiset, ds: AsyncDataset
+) -> None:
+    paths2keys = {
+        anxfile.file: anxfile.key async for anxfile in ds.aiter_annexed_files()
+    }
+    async with AsyncAnnex(ds.pathobj) as annex, httpx.AsyncClient(
+        headers={"User-Agent": USER_AGENT}
+    ) as s3client, aclosing(dandiset.aget_assets()) as ait:
+        async for asset in ait:
+            if isinstance(asset, RemoteBlobAsset):
+                try:
+                    sha256_digest = asset.get_digest_value(DigestType.sha2_256)
+                    assert sha256_digest is not None
+                except NotFoundError:
+                    raise NotImplementedError
+                else:
+                    blob = BlobBackup(
+                        asset=asset,
+                        sha256_digest=sha256_digest,
+                        manager=manager.with_sublogger(f"Asset {asset.path}"),
+                    )
+                    try:
+                        key = paths2keys[blob.path]
+                    except KeyError:
+                        continue
+                    if key2hash(key) == blob.sha256_digest:
+                        bucket_url = await blob.get_file_bucket_url(s3client)
+                        await blob.register_url(annex, key, bucket_url)
+            # else: asset is a Zarr and thus could not have been added while
+            # embargoed and thus is not missing S3 URLs

--- a/src/backups2datalad/register_s3.py
+++ b/src/backups2datalad/register_s3.py
@@ -41,6 +41,11 @@ async def register_s3urls(
                     try:
                         key = paths2keys.pop(blob.path)
                     except KeyError:
+                        # Either the asset is text (and thus not annexed and
+                        # thus not eligible to have URLs registered) or it was
+                        # added to the Dandiset since the previous backup (and
+                        # thus we don't have a local backup to register any
+                        # URLs on)
                         continue
                     if key2hash(key) == blob.sha256_digest:
                         bucket_url = await blob.get_file_bucket_url(s3client)

--- a/src/backups2datalad/register_s3.py
+++ b/src/backups2datalad/register_s3.py
@@ -31,7 +31,12 @@ async def register_s3urls(
                     sha256_digest = asset.get_digest_value(DigestType.sha2_256)
                     assert sha256_digest is not None
                 except NotFoundError:
-                    raise NotImplementedError
+                    manager.log.info(
+                        "%s: SHA256 has not been computed yet; not fetching any"
+                        " more assets",
+                        asset.path,
+                    )
+                    break
                 else:
                     blob = BlobBackup(
                         asset=asset,

--- a/src/backups2datalad/syncer.py
+++ b/src/backups2datalad/syncer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from dandi.consts import EmbargoStatus
+from ghrepo import GHRepo
 
 from .adandi import RemoteDandiset
 from .adataset import AsyncDataset
@@ -61,6 +62,13 @@ class Syncer:
             ):
                 self.log.info("Registering S3 URLs ...")
                 await register_s3urls(self.manager, self.dandiset, self.ds)
+                if self.config.gh_org is not None and await self.ds.has_github_remote():
+                    self.log.info("Making GitHub repository public ...")
+                    dandiset_id = self.dandiset.identifier
+                    await self.manager.edit_github_repo(
+                        GHRepo(self.config.gh_org, dandiset_id),
+                        private=False,
+                    )
 
     async def sync_assets(self) -> None:
         self.log.info("Syncing assets...")

--- a/src/backups2datalad/syncer.py
+++ b/src/backups2datalad/syncer.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from dandi.consts import EmbargoStatus
+
 from .adandi import RemoteDandiset
 from .adataset import AsyncDataset
 from .asyncer import Report, async_assets
 from .config import BackupConfig
 from .logging import PrefixedLogger
 from .manager import Manager
+from .register_s3 import register_s3urls
 from .util import AssetTracker, UnexpectedChangeError, quantify
 
 
@@ -17,10 +20,11 @@ class Syncer:
     dandiset: RemoteDandiset
     ds: AsyncDataset
     tracker: AssetTracker
+    error_on_change: bool
     deleted: int = 0
     # value of garbage_assets will be assigned but to pacify mypy - assign factory
     garbage_assets: list[str] = field(default_factory=list)
-    report: Report | None = None
+    report: Report = field(init=False, default_factory=Report)
 
     @property
     def config(self) -> BackupConfig:
@@ -30,23 +34,52 @@ class Syncer:
     def log(self) -> PrefixedLogger:
         return self.manager.log
 
-    async def sync_assets(self, error_on_change: bool = False) -> None:
+    async def update_embargo_status(self) -> None:
+        old_status = await self.ds.get_embargo_status()
+        new_status = self.dandiset.embargo_status
+        if old_status != new_status:
+            if self.error_on_change:
+                raise UnexpectedChangeError(
+                    f"Dandiset {self.dandiset.identifier}: Embargo status"
+                    f" changed from {old_status.value} to {new_status.value}"
+                    " but timestamp was not updated on server"
+                )
+            self.log.info(
+                "Updating embargo status from %s to %s",
+                old_status.value,
+                new_status.value,
+            )
+            await self.ds.set_embargo_status(self.dandiset.embargo_status)
+            commit_date = await self.ds.get_last_commit_date()
+            await self.ds.save(
+                "[backups2datalad] Update embargo status", commit_date=commit_date
+            )
+            self.report.commits += 1
+            if (
+                old_status is EmbargoStatus.EMBARGOED
+                and new_status is EmbargoStatus.OPEN
+            ):
+                self.log.info("Registering S3 URLs ...")
+                await register_s3urls(self.manager, self.dandiset, self.ds)
+
+    async def sync_assets(self) -> None:
         self.log.info("Syncing assets...")
-        self.report = await async_assets(
-            self.dandiset, self.ds, self.manager, self.tracker, error_on_change
+        report = await async_assets(
+            self.dandiset, self.ds, self.manager, self.tracker, self.error_on_change
         )
         self.log.info("Asset sync complete!")
-        self.log.info("%s added", quantify(self.report.added, "asset"))
-        self.log.info("%s updated", quantify(self.report.updated, "asset"))
-        self.log.info("%s registered", quantify(self.report.registered, "asset"))
+        self.log.info("%s added", quantify(report.added, "asset"))
+        self.log.info("%s updated", quantify(report.updated, "asset"))
+        self.log.info("%s registered", quantify(report.registered, "asset"))
         self.log.info(
-            "%s successfully downloaded", quantify(self.report.downloaded, "asset")
+            "%s successfully downloaded", quantify(report.downloaded, "asset")
         )
-        self.report.check()
+        report.check()
+        self.report.update(report)
 
-    async def prune_deleted(self, error_on_change: bool = False) -> None:
+    async def prune_deleted(self) -> None:
         for asset_path in self.tracker.get_deleted(self.config):
-            if error_on_change:
+            if self.error_on_change:
                 raise UnexpectedChangeError(
                     f"Dandiset {self.dandiset.identifier}: Asset {asset_path!r}"
                     " deleted from Dandiset but timestamp was not updated on"
@@ -76,7 +109,6 @@ class Syncer:
     def get_commit_message(self) -> str:
         msgparts = []
         if self.dandiset.version_id != "draft":
-            assert self.report is not None
             if self.report.added:
                 msgparts.append(f"{quantify(self.report.added, 'file')} added")
             if self.report.updated:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -40,7 +40,8 @@ def capture_all_logs(caplog: pytest.LogCaptureFixture) -> None:
 
 @pytest.fixture
 async def dandi_client() -> AsyncIterator[AsyncDandiClient]:
-    api_token = os.environ["DANDI_API_KEY"]
+    api_token = os.environ["DANDI_API_KEY"].strip()
+    assert api_token != "", "DANDI_API_KEY not set"
     async with AsyncDandiClient.for_dandi_instance(
         "dandi-staging", token=api_token
     ) as client:


### PR DESCRIPTION
Closes #8.

To do:

- [x] Decide how to handle assets missing SHA256 digests when registering S3 URLs (https://github.com/dandi/backups2datalad/issues/8#issuecomment-1874502017)
- [x] When a Dandiset is unembargoed, make the GitHub repository public
- [x] Add a command for just registering S3 URLs
- [x] Add tests