### PR TITLE
Ensure that we do not have saved dandiset.yaml flip flopping between two formattings

### DIFF
--- a/src/backups2datalad/util.py
+++ b/src/backups2datalad/util.py
@@ -5,7 +5,6 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import datetime
 from difflib import unified_diff
-from io import StringIO
 import json
 import os
 from pathlib import Path
@@ -17,10 +16,9 @@ from typing import TYPE_CHECKING, Any
 
 from dandi.consts import dandiset_metadata_file
 from dandi.dandiset import Dandiset
-from dandi.utils import yaml_load
+from dandi.utils import yaml_dump, yaml_load
 from datalad.api import Dataset
 from datalad.support.json_py import dump
-from ruamel.yaml import YAML
 
 from .config import BackupConfig
 from .consts import MINIMUM_GIT_ANNEX_VERSION
@@ -286,14 +284,6 @@ def diff_metadata(old: Any, new: Any) -> str:
             tofile="new-metadata",
         )
     )
-
-
-def yaml_dump(data: Any) -> str:
-    yaml = YAML(typ="safe")
-    yaml.default_flow_style = False
-    out = StringIO()
-    yaml.dump(data, out)
-    return out.getvalue()
 
 
 class UnexpectedChangeError(Exception):


### PR DESCRIPTION
like

```
    commit 828892d (HEAD -> draft, github/draft)
    Author: DANDI User <info@dandiarchive.org>
    Date:   2024 Apr 25 15:23:32 -0400

        [backups2datalad] Only some metadata updates

    diff --git a/dandiset.yaml b/dandiset.yaml
    index 5a43503..dc272a7 100644
    --- a/dandiset.yaml
    +++ b/dandiset.yaml
    @@ -1,7 +1,8 @@
     # DO NOT EDIT THIS FILE LOCALLY. ALL LOCAL UPDATES WILL BE LOST.
     # It can be edited online at https://dandiarchive.org/dandiset/000774
     # and obtained from the dandiarchive.
    -'@context': https://raw.githubusercontent.com/dandi/schema/master/releases/0.6.4/context.json
    +'@context':
    +  https://raw.githubusercontent.com/dandi/schema/master/releases/0.6.4/context.json

```

still not sure why, may be bug in ruaml.yaml. But now we will not bother saving unless there is actual change in metadata. Also removed duplicate `yaml_dump`