### PR TITLE
BF: Add Python 3.10 compatibility for datetime.fromisoformat with 'Z' suffix

### DIFF
--- a/src/backups2datalad/adataset.py
+++ b/src/backups2datalad/adataset.py
@@ -28,7 +28,7 @@ from .aioutil import areadcmd, aruncmd, stream_lines_command, stream_null_comman
 from .config import BackupConfig, Remote
 from .consts import DEFAULT_BRANCH, GIT_OPTIONS
 from .logging import log
-from .util import custom_commit_env, exp_wait, is_meta_file, key2hash
+from .util import custom_commit_env, exp_wait, fromisoformat, is_meta_file, key2hash
 
 EMBARGO_STATUS_KEY = "dandi.dandiset.embargo-status"
 
@@ -670,7 +670,7 @@ class AsyncDataset:
 
     async def get_last_commit_date(self) -> datetime:
         ts = await self.read_git("show", "-s", "--format=%aI")
-        return datetime.fromisoformat(ts)
+        return fromisoformat(ts)
 
     def assert_no_duplicates_in_gitmodules(self) -> None:
         filepath = self.pathobj / ".gitmodules"

--- a/src/backups2datalad/datasetter.py
+++ b/src/backups2datalad/datasetter.py
@@ -33,7 +33,13 @@ from .consts import DEFAULT_BRANCH, GIT_OPTIONS
 from .logging import PrefixedLogger, log, quiet_filter
 from .manager import GitHub, Manager
 from .syncer import Syncer
-from .util import AssetTracker, assets_eq, quantify, update_dandiset_metadata
+from .util import (
+    AssetTracker,
+    assets_eq,
+    fromisoformat,
+    quantify,
+    update_dandiset_metadata,
+)
 from .zarr import ZarrLink, sync_zarr
 
 
@@ -396,7 +402,7 @@ class DandiDatasetter(AsyncResource):
             ).splitlines()
             for cmt in commits:
                 chash, _, cdate = cmt.partition(" ")
-                ts = datetime.fromisoformat(cdate)
+                ts = fromisoformat(cdate)
                 if ts <= dandiset.version.created:
                     candidates.append(chash)
                     break
@@ -527,7 +533,7 @@ class DandiDatasetter(AsyncResource):
             if ts is None:
                 # Zarr was already up to date; get timestamp from its latest
                 # commit
-                ts = datetime.fromisoformat(
+                ts = fromisoformat(
                     await zds.read_git("show", "-s", "--format=%aI", "HEAD")
                 )
             assert not (ds.pathobj / asset.path).exists()

--- a/src/backups2datalad/util.py
+++ b/src/backups2datalad/util.py
@@ -213,6 +213,19 @@ async def update_dandiset_metadata(
     await ds.add(dandiset_metadata_file)
 
 
+def fromisoformat(date_string: str) -> datetime:
+    """
+    Parse an ISO 8601 date string, handling the 'Z' suffix for UTC.
+
+    Python 3.10's datetime.fromisoformat() doesn't support 'Z' suffix,
+    but Python 3.11+ does. This function provides compatibility.
+    """
+    # Replace 'Z' with '+00:00' for Python 3.10 compatibility
+    if date_string.endswith("Z"):
+        date_string = date_string[:-1] + "+00:00"
+    return datetime.fromisoformat(date_string)
+
+
 def quantify(qty: int, singular: str, plural: str | None = None) -> str:
     if qty == 1:
         return f"{qty} {singular}"


### PR DESCRIPTION
Python 3.10's datetime.fromisoformat() doesn't support the 'Z' suffix for UTC timezone, which was added in Python 3.11. This was causing ValueError when parsing ISO 8601 timestamps like '2025-10-07T17:26:51Z'.

Created a compatibility wrapper fromisoformat() in util.py that replaces 'Z' with '+00:00' before parsing, and updated all usages in datasetter.py and adataset.py to use this wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)