### PR TITLE
ENH: Add dynamic versioning using hatch-vcs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # Fetch all history for versioning to work
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .tox/
 __pycache__/
 dist/
+src/backups2datalad/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "backups2datalad"
-version = "0.0.0"
+dynamic = ["version"]
 description = "Mirror Dandisets as git-annex repositories"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -47,6 +47,12 @@ backups2datalad = "backups2datalad.__main__:main"
 
 [tool.hatch.envs.default]
 python = "3"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/backups2datalad/_version.py"
 
 [tool.mypy]
 allow_incomplete_defs = false

--- a/src/backups2datalad/__init__.py
+++ b/src/backups2datalad/__init__.py
@@ -4,7 +4,10 @@ Mirror Dandisets as git-annex repositories
 Visit <https://github.com/dandi/backups2datalad> for more information.
 """
 
-__version__ = "0.0.0"
+from ._version import __version__
+
+__all__ = ["__version__"]
+
 __author__ = "DANDI Developers"
 __author_email__ = "team@dandiarchive.org"
 __license__ = "MIT"

--- a/src/backups2datalad/__main__.py
+++ b/src/backups2datalad/__main__.py
@@ -13,9 +13,12 @@ import sys
 from typing import Concatenate, ParamSpec
 
 import asyncclick as click
+import dandi
 from dandi.consts import DANDISET_ID_REGEX, EmbargoStatus
+import dandischema
 from datalad.api import Dataset
 
+from . import __version__
 from .adandi import AsyncDandiClient
 from .adataset import AsyncDataset
 from .aioutil import pool_amap, stream_lines_command
@@ -58,6 +61,7 @@ from .util import check_git_annex_version, format_errors, pdb_excepthook, quanti
     is_flag=True,
     help="Log backups2datalad at DEBUG and all other loggers at INFO",
 )
+@click.version_option(__version__, "-V", "--version", message="%(version)s")
 @click.pass_context
 async def main(
     ctx: click.Context,
@@ -101,6 +105,9 @@ async def main(
         level=getattr(logging, log_level),
     )
     await ctx.obj.debug_logfile(quiet_debug)
+    log.info("backups2datalad version: %s", __version__)
+    log.info("dandi version: %s", dandi.__version__)
+    log.info("dandischema version: %s", dandischema.__version__)
     log.info("COMMAND: %s", shlex.join(sys.argv))
 
 


### PR DESCRIPTION
Replaced hardcoded version "0.0.0" with git-tag-based versioning using hatch-vcs.

Changes:
- Added hatch-vcs to build-system requirements in pyproject.toml
- Configured hatch to use VCS as version source
- Generated _version.py file automatically from git tags
- Added --version/-V option to CLI
- Log backups2datalad, dandi, and dandischema versions at startup
- Updated GitHub Actions workflow to fetch full git history (fetch-depth: 0) for proper versioning in CI

Version now automatically derived from git tags using CalVer format (0.YYYYMMDD.patch). Development versions show as tag+commits.hash (e.g., 0.20250623.1.dev22+ge93057ab4.d20251007).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

and I have already pushed some tags marking prior "stable states" so this portion should work