### PR TITLE
Fix test flakiness by using unique tmp directory names per dandiset

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -422,7 +422,7 @@ async def new_dandiset(
         },
     )
     dandiset_id = d.identifier
-    dspath = tmp_path_factory.mktemp("new_dandiset")
+    dspath = tmp_path_factory.mktemp(f"new_dandiset_{dandiset_id}")
     (dspath / dandiset_metadata_file).write_text(f"identifier: '{dandiset_id}'\n")
     ds = SampleDandiset(
         client=dandi_client,
@@ -455,7 +455,7 @@ async def embargoed_dandiset(
         embargo=True,
     )
     dandiset_id = d.identifier
-    dspath = tmp_path_factory.mktemp("embargoed_dandiset")
+    dspath = tmp_path_factory.mktemp(f"embargoed_dandiset_{dandiset_id}")
     (dspath / dandiset_metadata_file).write_text(f"identifier: '{dandiset_id}'\n")
     ds = SampleDandiset(
         client=dandi_client,


### PR DESCRIPTION
Use dandiset_id in tmp_path_factory.mktemp() calls to ensure each fixture instance gets a unique temporary directory path. Previously, all new_dandiset instances used "new_dandiset" which resulted in sequential naming (new_dandiset0, new_dandiset1, etc.) that could cause confusion and potential state leakage between tests.

This change ensures that even when tmp_path_factory's session-scoped counter increments, each dandiset gets a clearly identifiable and unique directory path based on its actual dandiset ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

I don't think it will but may be fully or partially addresses #87 , let's see what CI says. In any case - change seems to be minimal and kinda making sense