### PR TITLE
Stop 403-flooding runs: retry get_repo on 403 + log response body

### DIFF
--- a/src/backups2datalad/aioutil.py
+++ b/src/backups2datalad/aioutil.py
@@ -132,6 +132,14 @@ async def arequest(
             r = await client.request(method, url, follow_redirects=True, **kwargs)
             r.raise_for_status()
         except (httpx.HTTPError, ssl.SSLError) as e:
+            # For HTTP status errors, capture body + rate-limit/retry headers
+            # so 403s (esp. GitHub secondary rate limits) can be distinguished
+            # from auth/permission failures in the logs.
+            err_detail = (
+                _describe_http_error(e.response)
+                if isinstance(e, httpx.HTTPStatusError)
+                else ""
+            )
             if isinstance(e, (httpx.RequestError, ssl.SSLError)) or (
                 isinstance(e, httpx.HTTPStatusError)
                 and (
@@ -141,20 +149,54 @@ async def arequest(
                 try:
                     delay = next(waits)
                 except StopIteration:
+                    if err_detail:
+                        log.error(
+                            "Giving up on %s request to %s after retries; %s",
+                            method.upper(),
+                            url,
+                            err_detail,
+                        )
                     raise e
                 log.warning(
-                    "Retrying %s request to %s in %f seconds as it raised %s: %s",
+                    "Retrying %s request to %s in %f seconds as it raised %s: %s%s",
                     method.upper(),
                     url,
                     delay,
                     type(e).__name__,
                     str(e),
+                    f"; {err_detail}" if err_detail else "",
                 )
                 await anyio.sleep(delay)
                 continue
             else:
+                if err_detail:
+                    log.error(
+                        "%s request to %s failed: %s; %s",
+                        method.upper(),
+                        url,
+                        str(e),
+                        err_detail,
+                    )
                 raise
         return r
+
+
+def _describe_http_error(response: httpx.Response) -> str:
+    parts = []
+    for hdr in (
+        "retry-after",
+        "x-ratelimit-remaining",
+        "x-ratelimit-reset",
+        "x-ratelimit-resource",
+    ):
+        value = response.headers.get(hdr)
+        if value is not None:
+            parts.append(f"{hdr}={value}")
+    body = response.text
+    if body:
+        body = textwrap.shorten(body.replace("\n", " "), width=500, placeholder="...")
+        parts.append(f"body={body!r}")
+    return "; ".join(parts)
 
 
 @dataclass

--- a/src/backups2datalad/datasetter.py
+++ b/src/backups2datalad/datasetter.py
@@ -243,7 +243,20 @@ class DandiDatasetter(AsyncResource):
                     data="nothing",
                     force=self.config.should_force_push_dandisets(),
                 )
-            await self.manager.set_dandiset_description(dandiset, stats, ds)
+            # Only refresh GitHub description / visibility when we actually
+            # changed something or the user explicitly asked for FORCE mode.
+            # Doing this unconditionally produced a `GET /repos/...` per
+            # dandiset per run (~22 req/s with default workers), which is the
+            # exact burst that trips GitHub's secondary rate limit and floods
+            # the log with 403's.  `update-github-metadata` remains the
+            # explicit escape hatch for an out-of-band refresh.
+            if changed or dmanager.config.mode is Mode.FORCE:
+                await self.manager.set_dandiset_description(dandiset, stats, ds)
+            else:
+                dmanager.log.debug(
+                    "Skipping GitHub description refresh: no commits and"
+                    " mode is not 'force'"
+                )
         return changed
 
     async def sync_dataset(

--- a/src/backups2datalad/manager.py
+++ b/src/backups2datalad/manager.py
@@ -131,7 +131,11 @@ class GitHub(AsyncResource):
 
     async def get_repo(self, repo: GHRepo) -> dict[str, Any]:
         log.debug("Getting repository info for %s", repo)
-        r = await arequest(self.client, "GET", repo.api_url)
+        # Retry on 403's: GitHub's secondary (abuse) rate limit returns 403
+        # under bursty parallel access, even when the primary 5000/hr budget
+        # is far from exhausted.  edit_repo already retries on 403 for the
+        # same reason.
+        r = await arequest(self.client, "GET", repo.api_url, retry_on=[403])
         data = r.json()
         assert isinstance(data, dict), f"Expected dict, got {type(data)}"
         assert all(

--- a/src/backups2datalad/zarr.py
+++ b/src/backups2datalad/zarr.py
@@ -587,7 +587,8 @@ async def sync_zarr(
             )
             await zsync.run()
         report = zsync.report
-        if report or await zsync.ds.is_dirty():
+        made_commit = bool(report) or await zsync.ds.is_dirty()
+        if made_commit:
             if report:
                 summary = report.get_summary()
             else:
@@ -618,7 +619,13 @@ async def sync_zarr(
         else:
             manager.log.info("no changes; not committing")
         if link is not None:
-            if manager.gh is not None:
+            # Mirror the dandiset-side gate (datasetter.update_dandiset): only
+            # refresh the GitHub description when we actually changed
+            # something or the user asked for FORCE mode, so a no-op cron
+            # doesn't fan out into one `GET /repos/...` per zarr.
+            if manager.gh is not None and (
+                made_commit or manager.config.zarr_mode is ZarrMode.FORCE
+            ):
                 stats = await ds.get_stats(config=manager.config)
                 await manager.set_zarr_description(asset.zarr, stats)
             link.commit_hash = await ds.get_commit_hash()

--- a/test/data/dandiarchive-docker/docker-compose.yml
+++ b/test/data/dandiarchive-docker/docker-compose.yml
@@ -110,6 +110,11 @@ services:
       retries: 5
 
   rabbitmq:
-    image: rabbitmq:management
+    # Pinned to 4.2-management to match dandi-cli's test docker-compose;
+    # newer `:management` tags broke the dandi-archive celery wire-up and
+    # caused Zarr-upload tests to hang forever in "server calculating
+    # checksum" because celery never picked up the calculate_sha256 /
+    # ingest_zarr_archive jobs.  See dandi/dandi-cli#1841.
+    image: rabbitmq:4.2-management
     expose:
       - "5672"

--- a/test/test_aioutil.py
+++ b/test/test_aioutil.py
@@ -1,0 +1,174 @@
+"""
+Integration tests for ``arequest``'s error-diagnostics logging.
+
+These spin up a real local HTTP server returning ``403 Forbidden`` with a
+GitHub-secondary-rate-limit-shaped body and ``retry-after`` /
+``x-ratelimit-*`` headers, then drive ``arequest`` against it with httpx so
+that the full path through ``_describe_http_error`` is exercised against
+real ``httpx.Response`` objects — not a mocked-out response — to catch
+breakage if httpx changes how headers/body are surfaced.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import logging
+import threading
+
+import httpx
+import pytest
+
+from backups2datalad.aioutil import arequest
+
+pytestmark = pytest.mark.anyio
+
+
+# A canned body that mimics what GitHub returns when the secondary
+# (abuse) rate limit fires.  We assert substrings of this in the logs.
+_RATE_LIMIT_BODY = (
+    b'{"message":"You have exceeded a secondary rate limit. '
+    b'Please wait a few minutes before you try again.",'
+    b'"documentation_url":"https://docs.github.com/rest/overview/'
+    b'resources-in-the-rest-api#secondary-rate-limits"}'
+)
+
+
+def _make_handler(
+    responses: list[tuple[int, bytes]],
+    counter: dict[str, int],
+) -> type[BaseHTTPRequestHandler]:
+    """
+    Build a one-shot HTTP handler class that returns each response in
+    ``responses`` in order, cycling on the last entry, recording the
+    number of requests served in ``counter['count']``.
+    """
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            n = counter["count"]
+            counter["count"] = n + 1
+            status, body = responses[min(n, len(responses) - 1)]
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            if status == 403:
+                self.send_header("Retry-After", "1")
+                self.send_header("X-RateLimit-Remaining", "0")
+                self.send_header("X-RateLimit-Reset", "1234567890")
+                self.send_header("X-RateLimit-Resource", "core")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, fmt: str, *args: object) -> None:  # noqa: A003
+            pass  # silence default stderr access log
+
+    return Handler
+
+
+@contextmanager
+def _serve(
+    handler_cls: type[BaseHTTPRequestHandler],
+) -> Iterator[str]:
+    server = HTTPServer(("127.0.0.1", 0), handler_cls)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.mark.ai_generated
+async def test_arequest_403_no_retry_logs_body_and_headers(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    With ``retry_on=()`` a 403 must propagate immediately, and an ERROR-level
+    log emitted just before the raise must include the response body excerpt
+    and the rate-limit / retry-after headers.
+    """
+    counter: dict[str, int] = {"count": 0}
+    handler_cls = _make_handler([(403, _RATE_LIMIT_BODY)], counter)
+    with caplog.at_level(logging.DEBUG, logger="backups2datalad"):
+        with _serve(handler_cls) as base_url:
+            async with httpx.AsyncClient() as client:
+                with pytest.raises(httpx.HTTPStatusError):
+                    await arequest(client, "GET", f"{base_url}/repos/dandisets/000005")
+
+    assert counter["count"] == 1, "Should have made exactly one request (no retry)"
+
+    error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert error_records, (
+        "Expected an ERROR log emitted before the final raise; "
+        f"got records: {[(r.levelno, r.getMessage()) for r in caplog.records]}"
+    )
+    msg = "\n".join(r.getMessage() for r in error_records)
+    assert "secondary rate limit" in msg, msg
+    assert "retry-after=1" in msg, msg
+    assert "x-ratelimit-remaining=0" in msg, msg
+    assert "x-ratelimit-reset=1234567890" in msg, msg
+    assert "x-ratelimit-resource=core" in msg, msg
+
+
+@pytest.mark.ai_generated
+async def test_arequest_403_retries_and_warning_carries_details(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    With ``retry_on=[403]`` (matching ``GitHub.get_repo`` and
+    ``GitHub.edit_repo``) the request must retry; the WARNING emitted before
+    the sleep must include the same body + header diagnostics.
+    """
+    counter: dict[str, int] = {"count": 0}
+    handler_cls = _make_handler(
+        [(403, _RATE_LIMIT_BODY), (200, b'{"ok": true}')],
+        counter,
+    )
+    with caplog.at_level(logging.DEBUG, logger="backups2datalad"):
+        with _serve(handler_cls) as base_url:
+            async with httpx.AsyncClient() as client:
+                r = await arequest(
+                    client,
+                    "GET",
+                    f"{base_url}/repos/dandisets/000005",
+                    retry_on=[403],
+                )
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+    assert counter["count"] == 2, "Expected one 403 retry then one 200"
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, (
+        "Expected a WARNING log on retry; "
+        f"got records: {[(r.levelno, r.getMessage()) for r in caplog.records]}"
+    )
+    msg = "\n".join(r.getMessage() for r in warnings)
+    assert "Retrying GET request" in msg, msg
+    assert "secondary rate limit" in msg, msg
+    assert "retry-after=1" in msg, msg
+    assert "x-ratelimit-remaining=0" in msg, msg
+
+
+@pytest.mark.ai_generated
+async def test_arequest_2xx_emits_no_error_diagnostics(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Sanity check: a successful response must not invoke the diagnostics path
+    or emit any ERROR / WARNING records.  Guards against the helper being
+    accidentally wired into the happy path.
+    """
+    counter: dict[str, int] = {"count": 0}
+    handler_cls = _make_handler([(200, b'{"ok": true}')], counter)
+    with caplog.at_level(logging.DEBUG, logger="backups2datalad"):
+        with _serve(handler_cls) as base_url:
+            async with httpx.AsyncClient() as client:
+                r = await arequest(client, "GET", f"{base_url}/whatever")
+    assert r.status_code == 200
+    assert counter["count"] == 1
+    for record in caplog.records:
+        assert record.levelno < logging.WARNING, record.getMessage()


### PR DESCRIPTION
## Summary

This PR addresses two distinct production / CI issues found while investigating a 403-flood incident:

**1. The 403 flood (`set_*_description`).** A nightly cron run (`2026.05.21.01.00.11Z.log`, 21:00 EDT) failed with **670 identical `403 Forbidden` errors**, one per dandiset, all from `GET https://api.github.com/repos/dandisets/<id>` in `Manager.set_dandiset_description` -> `GitHub.get_repo`. The API token was *not* expired — the run immediately prior (20:32 EDT) and the next run (21:12 EDT) both succeeded. The failure is consistent with GitHub's **secondary (abuse) rate limit** kicking in. Root cause: `update_dandiset` and `sync_zarr` called their respective `set_*_description` helpers **unconditionally** at the end of every run — even when the syncer had just logged "Remote Dandiset has not been modified since last backup; not syncing". With ~1100 dandisets and `DEFAULT_WORKERS = 5`, every no-op cron cycle fanned out into ~22 same-endpoint `GET /repos/...` calls per second for 30 s straight.

**2. CI hung for 2h+ on Zarr upload (rabbitmq).** While preparing this PR, the test workflow stalled on `test/test_commands.py::test_populate` at `{'status': 'server calculating checksum'}` for 2 h 6 m before being cancelled. Diagnosis: our `test/data/dandiarchive-docker/docker-compose.yml` used `rabbitmq:management` (unpinned). dandi-cli had already hit and fixed this in 0.75.0 by pinning to `4.2-management` (PR [dandi/dandi-cli#1841](https://github.com/dandi/dandi-cli/pull/1841)); our docker-compose is documented as "Based on" theirs but the pin was never propagated. When Docker Hub's `:management` tag drifted to an incompatible version, celery stopped picking up the `calculate_sha256` / `ingest_zarr_archive` jobs and dandi-cli's upload polling loop waited forever.

Layout of the fix:

- **Real fix for #1 (b49b356):** skip the description refresh entirely when nothing committed, unless the user asked for FORCE mode. Eliminates the burst at its source.
- **Defense in depth for #1 (42c7bfb, 80725f2, d6b3243):** when something *does* genuinely need to talk to the GitHub API and the secondary limit still trips, `get_repo` now retries on 403 (matching `edit_repo`'s existing policy) and `arequest` logs the response body + `retry-after` / `x-ratelimit-*` headers so the next 403 we see is self-diagnosing.
- **Fix for #2 (3c9806f):** mirror upstream's rabbitmq pin.

## Commits

- 42c7bfb `aioutil: log response body + rate-limit headers on HTTP errors`
- 80725f2 `manager: retry get_repo on 403 (GitHub secondary rate limit)`
- d6b3243 `test: cover arequest's 403-diagnostics path against a real HTTP server`
- b49b356 `Skip set_*_description on no-op runs (eliminate the 403-flood vector)`
- 3c9806f `tests: pin rabbitmq image to 4.2-management`

<details><summary>Per-commit details</summary>

### 42c7bfb `aioutil: log response body + rate-limit headers on HTTP errors`

`arequest` previously raised `httpx.HTTPStatusError` with only URL + status code, so 403 floods are indistinguishable from auth / permission failures without re-running by hand. Adds a `_describe_http_error()` helper that pulls a truncated response body plus `retry-after`, `x-ratelimit-remaining`, `x-ratelimit-reset`, `x-ratelimit-resource` headers, and includes that detail in:

- the retry warning
- the "giving up after N retries" path (new `log.error` before the final raise)
- the no-retry raise path (new `log.error` before raising)

Logs land in the superdataset's `.git/dandi/backups2datalad/YYYY/MM/*.log` (see `DandiDatasetter.debug_logfile()` at `datasetter.py:680`), so next time a 403 flood happens, GitHub's secondary-rate-limit message body ("You have exceeded a secondary rate limit...") will be in the archived log alongside the rate-limit headers, distinct from a revoked token or a real permission denial.

### 80725f2 `manager: retry get_repo on 403 (GitHub secondary rate limit)`

Match `edit_repo`'s existing retry policy. Just `[403]`, not `[403, 404]`: for `get_repo`, a 404 means the repo genuinely doesn't exist, and the only caller (`set_dandiset_description`) runs after `ensure_github_remote()` + the push, so the repo is already created by then.

### d6b3243 `test: cover arequest's 403-diagnostics path against a real HTTP server`

Adds `test/test_aioutil.py` driving `arequest` end-to-end against a stdlib `http.server` returning a GitHub-shaped 403 (Retry-After + X-RateLimit-* headers, "secondary rate limit" JSON body), exercising the full integration through `_describe_http_error` — no `MockTransport`, no mocked `Response`. Three cases:

1. `retry_on=()` → 403 propagates immediately, ERROR log carries body + all four rate-limit headers.
2. `retry_on=[403]` → request retries; WARNING before sleep carries body + headers; follow-up 200 lets the test finish in ~1 s.
3. Happy path → 2xx emits no WARNING / ERROR records (guards against the helper being wired into the success path).

Verified that reverting the diagnostics code makes the two assertion tests fail (sanity test still passes), so they really do exercise the new behaviour.

### b49b356 `Skip set_*_description on no-op runs (eliminate the 403-flood vector)`

Gate `set_dandiset_description` (`datasetter.py:246`) and `set_zarr_description` (`zarr.py:623`) on `committed_locally or mode is FORCE`. Before this commit, both ran unconditionally at the end of every per-dandiset / per-zarr cycle, even when the syncer logged "Remote Dandiset has not been modified since last backup; not syncing" — so every no-op cron cycle still did ~1100 `GET /repos/...` + ~1100 `dandiset.aget_raw_metadata()` + ~1100 `aget_versions()` iterations. The `_set_github_description` short-circuit on `dandi.github-description` in `.datalad/config` only saved us the PATCH; the GET + DANDI metadata fetch happened anyway.

After: a no-op cron makes zero calls into `set_*_description`. New dandisets / zarrs still get described (they go through `sync_dataset` → `changed = True`). Privacy flips driven by embargo status changes happen inside `sync_dataset` / `Syncer.update_embargo_status()`, also unaffected.

`update-github-metadata` (`datasetter.py:305`) is the explicit escape hatch and is unchanged — that subcommand exists for exactly this kind of out-of-band refresh.

Tradeoff to keep in mind: if `describe_dandiset()`'s template ever changes, unchanged dandisets won't pick up the new text until their next natural sync or until you run `--mode force` / `update-github-metadata`. Worth it vs. thousands of redundant API calls per cycle.

### 3c9806f `tests: pin rabbitmq image to 4.2-management`

CI run [26230267907](https://github.com/dandi/backups2datalad/actions/runs/26230267907) hung for 2 h 6 m on `test/test_commands.py::test_populate` at `{'status': 'server calculating checksum'}` during a 660-byte Zarr upload — celery never picked up the `calculate_sha256` / `ingest_zarr_archive` jobs because the unpinned `rabbitmq:management` image had drifted to a version incompatible with dandi-archive's celery wire-up. dandi-cli already hit this in 0.75.0 and pinned to `4.2-management` ([dandi/dandi-cli#1841](https://github.com/dandi/dandi-cli/pull/1841)); our docker-compose was documented as "Based on" theirs but the pin was never propagated. This commit mirrors the upstream pin.

Other upstream divergences in our compose file (Minio curl-based healthcheck, `127.0.0.1` vs `localhost` for `DJANGO_MINIO_STORAGE_MEDIA_URL`, postgres log flags, celery `nofile` ulimits, removal of `createbuckets`) are intentionally left out of this commit — `createbuckets` is still referenced by `test/conftest.py`, and the others are cosmetic for our setup. Worth a follow-up "sync compose with dandi-cli upstream" PR.

</details>

<details><summary>403 failure trace (from the cron log)</summary>

```
2026-05-20T21:00:17-0400 [ERROR] backups2datalad: Job failed on input <Dandiset 000005/draft>:
Traceback (most recent call last):
  File ".../backups2datalad/aioutil.py", line 177, in dowork
    outp = await func(inp)
  File ".../backups2datalad/datasetter.py", line 246, in update_dandiset
    await self.manager.set_dandiset_description(dandiset, stats, ds)
  File ".../backups2datalad/manager.py", line 68, in set_dandiset_description
    repo_info = await self.gh.get_repo(repo)
  File ".../backups2datalad/manager.py", line 134, in get_repo
    r = await arequest(self.client, "GET", repo.api_url)
  File ".../backups2datalad/aioutil.py", line 133, in arequest
    r.raise_for_status()
httpx.HTTPStatusError: Client error '403 Forbidden' for url 'https://api.github.com/repos/dandisets/000005'
[... 669 more identical traces, one per dandiset, all within 21:00:17 - 21:00:45 ...]
RuntimeError: Backups for 670 Dandisets failed
```

</details>

<details><summary>CI hang signature (from cancelled run 26230267907)</summary>

```
13:53:04  test/test_aioutil.py (3 cases)  PASSED   ← new tests work on CI
13:53:48  test/test_commands.py::test_backup_command  ...  FAILED (0-byte downloads — same root cause)
13:54:42  test/test_commands.py::test_populate  ...
                      [uploads several blobs successfully]
13:54:43  {'status': 'traversing local Zarr'}
13:54:43  {'status': 'initiating upload', 'size': 660}
13:54:43  {'status': 'uploading', 'progress': 96.21...}
13:54:43  {'status': 'uploading', 'progress': 100.0}
13:54:43  {'status': 'server calculating checksum'}    ← stuck here
16:00:20  ##[error]The operation was canceled.
```

Both failures share root cause: celery isn't processing async tasks (sha256 + zarr ingest), so the server never finishes calculating checksums; `test_backup_command` shows it as 0-byte downloads (blob assets without backing-store URLs), `test_populate` shows it as a hung Zarr upload.

</details>

## Test plan

- [x] `test/test_aioutil.py` (3 cases) passes locally and on CI (verified at 13:53:04 in run 26230267907 before the rabbitmq-induced hang).
- [x] Tests verified to fail when the diagnostics code is reverted, confirming they exercise the new path.
- [x] `flake8 src test` passes (incl. bugbear / builtins / unused-arguments).
- [x] `mypy src test` clean (26 source files).
- [x] pre-commit (black + isort + flake8) clean on all five commits.
- [ ] **Pending:** new CI run on this branch completes with rabbitmq pinned (verifies #2 fixed and there's no other CI regression).
- [ ] Next no-op cron cycle on drogon should show **zero** GitHub API calls from `set_*_description` (the log will simply be quiet — the new debug-level "Skipping GitHub description refresh" message confirms the path was hit).
- [ ] First real-change cron cycle after merge should still update descriptions for the changed dandisets / zarrs only.
- [ ] No focused unit test for the new `set_*_description` gate — the change is small + well-commented + the existing docker-based integration tests in CI already exercise `update_dandiset` and `sync_zarr` end-to-end. A focused unit test would require substantial mocking of `init_dataset` / `sync_dataset` / `ensure_github_remote` / `tag_releases`; we judged the cost not worth it for two-line gates. Happy to add one on request.
