### PR TITLE
TST: handle Zarr v3 size and wait for server SHA-256 in upload fixture

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -18,6 +18,7 @@ from dandi.consts import DandiInstance, dandiset_metadata_file, known_instances
 from dandi.exceptions import NotFoundError
 from dandi.upload import upload
 from dandischema.consts import DANDI_SCHEMA_VERSION
+from dandischema.models import DigestType
 from datalad.api import Dataset
 from datalad.tests.utils_pytest import assert_repo_status
 import pytest
@@ -307,6 +308,45 @@ class SampleDandiset:
                 **kwargs,
             )
         )
+        # dandi-cli's `upload()` returns as soon as the asset is registered
+        # with the API, but the SHA-256 digest is computed asynchronously by
+        # the dandi-archive celery worker.  `update-from-backup` skips the
+        # download for any asset whose SHA-256 isn't ready yet, which
+        # produced flaky "missing file" failures in `test_backup_command`
+        # (see CI run 26239575722 / pre-existing `test_binary` flake on
+        # main).  Wait until the server has computed digests for every blob
+        # asset we just uploaded before returning, so callers can run
+        # `update-from-backup` deterministically.
+        await self._wait_for_blob_digests()
+
+    async def _wait_for_blob_digests(
+        self, timeout: float = 60.0, poll_interval: float = 1.0
+    ) -> None:
+        expected = set(self.text_assets) | set(self.blob_assets)
+        if not expected:
+            return
+        deadline = anyio.current_time() + timeout
+        not_ready: list[str] = list(expected)
+        while True:
+            not_ready = []
+            async for asset in self.dandiset.aget_assets():
+                if asset.path not in expected:
+                    continue
+                try:
+                    sha = asset.get_digest_value(DigestType.sha2_256)
+                except NotFoundError:
+                    sha = None
+                if sha is None:
+                    not_ready.append(asset.path)
+            if not not_ready:
+                return
+            if anyio.current_time() >= deadline:
+                raise TimeoutError(
+                    f"dandi-archive did not compute SHA-256 for"
+                    f" {len(not_ready)} asset(s) within {timeout}s:"
+                    f" {sorted(not_ready)}"
+                )
+            await anyio.sleep(poll_interval)
 
     async def check_backup(
         self, backup_ds: Dataset, zarr_root: Path | None = None

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 import json
 from pathlib import Path
@@ -127,3 +127,21 @@ def unzulu(ts: str) -> str:
     # as "Z" rather than "+00:00", which breaks comparisons against stringified
     # Python datetimes.
     return re.sub(r"Z$", "+00:00", ts)
+
+
+def zarr_format_of(names: Iterable[str]) -> str:
+    """Return the Zarr serialisation format ("2" or "3") implied by a Zarr
+    store's file inventory.
+
+    V3 stores carry ``zarr.json`` array/group metadata files; V2 stores carry
+    ``.zarray`` / ``.zgroup``.  ``zarr.save`` defaults to whichever format the
+    installed ``zarr-python`` version writes — that's V2 in zarr-python 2.x
+    and V3 in 3.x, and on-disk digests / sizes differ between the two
+    layouts (see dandi/dandi-cli#1858).
+    """
+    seen = set(names)
+    if any(n.endswith("zarr.json") for n in seen):
+        return "3"
+    if any(n.endswith(".zarray") or n.endswith(".zgroup") for n in seen):
+        return "2"
+    raise ValueError(f"Cannot determine Zarr format from files: {sorted(seen)!r}")

--- a/test/test_zarr.py
+++ b/test/test_zarr.py
@@ -9,7 +9,7 @@ from conftest import Archive, SampleDandiset
 from datalad.api import Dataset
 import numpy as np
 import pytest
-from test_util import GitRepo
+from test_util import GitRepo, zarr_format_of
 
 from backups2datalad.adandi import RemoteZarrAsset
 from backups2datalad.adataset import AsyncDataset, DatasetStats
@@ -89,8 +89,15 @@ async def test_backup_zarr(
     assert gitrepo.get_commit_count() == 3
     assert gitrepo.get_commit_subject("HEAD") == "[backups2datalad] 2 files added"
 
+    # On-disk size of the Zarr store differs between zarr-python's V2 layout
+    # (.zarray / .zgroup, default in zarr-python 2.x) and V3 layout
+    # (zarr.json, default in 3.x); see dandi/dandi-cli#1858 for the same
+    # accommodation upstream.
+    expected_zarr_size = {"2": 1535, "3": 3954}[
+        zarr_format_of(new_dandiset.zarr_assets["sample.zarr"])
+    ]
     assert await AsyncDataset(ds.pathobj).get_stats(config=di.config) == DatasetStats(
-        files=6, size=1535
+        files=6, size=expected_zarr_size
     )
 
     log.info("test_backup_zarr: Syncing unmodified Zarr dandiset")


### PR DESCRIPTION
## Summary

Two follow-up CI fixes for issues that #100 unmasked once the rabbitmq pin let CI actually finish running tests:

1. **`test_backup_zarr` Zarr v3 on-disk size.** Hardcoded `DatasetStats(files=6, size=1535)` was correct for zarr-python 2.x's V2 layout; zarr-python 3.x defaults to V3 (`zarr.json` + `c/<chunk>` layout, different compressor) which serialises the same input to 3954 bytes. Same `2419`-byte delta upstream dandi-cli observed in [#1858](https://github.com/dandi/dandi-cli/pull/1858). Detect the actually-produced format and select the expected size; helper lives in `test/test_util.py` so future tests touching Zarr sizes can reuse it.

2. **`SampleDandiset.upload` race with server SHA-256.** `dandi.upload()` registers the asset with the API immediately, but the SHA-256 is computed by an asynchronous celery task. `update-from-backup` skips downloads for blobs whose `dandi:sha2-256` isn't populated yet, so tests that drive `update-from-backup` directly after `upload()` race the celery worker and the backup commits with missing assets. CI run 26239575722's py3.10 `test_backup_command` failed this way (missing `v0.txt` + `subdir2/coconut.txt`); same shape as the long-standing `test_binary` flake on weekly main runs since at least 2026-01-25. Add a deadline-bounded poll in `SampleDandiset.upload()` that returns only once every uploaded blob has a populated SHA-256.

Neither is a regression from #100 — both were pre-existing and would have hit the next CI cycle either way.

## Commits

- 7a7c382 `test_backup_zarr: accept Zarr v2 or v3 on-disk size`
- 42fb69e `SampleDandiset.upload: wait for server SHA-256 digests`

<details><summary>Per-commit details</summary>

### 7a7c382 `test_backup_zarr: accept Zarr v2 or v3 on-disk size`

- New `zarr_format_of(names)` helper in `test/test_util.py` — returns `"2"` or `"3"` based on whether `zarr.json` or `.zarray`/`.zgroup` appear in the Zarr store's file inventory.
- `test_backup_zarr` (test/test_zarr.py:92) now derives the expected size from `{"2": 1535, "3": 3954}[zarr_format_of(new_dandiset.zarr_assets["sample.zarr"])]` instead of a single hard-coded value.
- The numerical delta `3954 - 1535 = 2419` matches dandi-cli's own observation in [#1858](https://github.com/dandi/dandi-cli/pull/1858) (`3935 - 1516`), confirming this is the V2/V3 default-compressor + chunk-encoding difference and not something specific to our backup pipeline.
- Future-friendly: when a tagged dandi release ships `dandi.tests.test_helpers.zarr_format_of` upstream, swap the local helper for the upstream one.

### 42fb69e `SampleDandiset.upload: wait for server SHA-256 digests`

- New private `_wait_for_blob_digests(timeout=60s, poll_interval=1s)` polls `dandiset.aget_assets()` until every text/blob asset has `metadata.digest["dandi:sha2-256"]` populated.
- Called automatically at the end of every `upload()`, so the fixture's `await new_dandiset.upload()` returns only once the server has done its part. Tests that subsequently drive `update-from-backup` no longer race the celery worker.
- Zarr assets are correctly excluded — they don't have a SHA-256 (their `digest_type` is `dandi-zarr-checksum`) and aren't members of `text_assets` / `blob_assets`.
- Raises `TimeoutError` listing the laggard paths if the celery worker doesn't finish within 60 s — surfacing a stuck stack rather than silently skipping like the syncer's production code path does. (We're in test infra; failing loudly is the right call.)

</details>

<details><summary>Original failure traces</summary>

**py3.10 `test_backup_command`:**

```
FAILED test/test_commands.py::test_backup_command - AssertionError:
  assert {'subdir1/apple.txt', 'dandiset.yaml', '.dandi/assets-state.json',
          'subdir2/banana.txt', 'file.txt', '.dandi/assets.json'}
      == {'v0.txt', '.dandi/assets.json', 'subdir1/apple.txt',
          'subdir2/banana.txt', 'file.txt', 'dandiset.yaml',
          'subdir2/coconut.txt', '.dandi/assets-state.json'}
```

Preceded in log by 30+ `Summary: 0 Bytes / <N> Bytes/s` lines and trailed by
`INFO dandi:bases.py:470 subdir2/coconut.txt: Asset successfully uploaded` /
`INFO dandi:bases.py:470 v0.txt: Asset successfully uploaded` — i.e. the
missing-from-backup files were the latest to finish server-side processing.

**py3.11 / py3.12 / py3.13 `test_backup_zarr`:**

```
FAILED test/test_zarr.py::test_backup_zarr - AssertionError:
  assert DatasetStats(files=6, size=3954) == DatasetStats(files=6, size=1535)
```

Identical failure across all three Python versions that got that far — the file count matched, only the size differed. zarr-python 3.1.5 was installed in all three.

</details>

## Test plan

- [x] `flake8 src test` clean (incl. bugbear / builtins / unused-arguments).
- [x] `mypy src test` clean (26 source files).
- [x] pre-commit (black + isort + flake8) clean on both commits.
- [x] Helper logic for `zarr_format_of` smoke-tested with synthesised file inventories: `{zarr.json}` → "3", `{.zarray}` → "2", `{.zgroup}` → "2", unrelated paths → `ValueError`.
- [ ] CI run on this branch shows `test_backup_zarr` passing on py3.11/3.12/3.13 with zarr 3.x.
- [ ] CI run on this branch shows `test_backup_command` consistently passing across all matrix entries (the race-prone failure was previously hitting one matrix entry per scheduled run).
- [ ] No focused unit tests for either change — the Zarr fix only meaningfully exercises against a real Zarr store, and the race fix only meaningfully exercises against a real dandi-archive. CI integration tests are the test plan.

## Follow-ups (not in this PR)

- A larger refactor — already in flight on a separate branch — switches our test stack to consume dandi-cli's published `pytest11` plugin (drops the vendored `docker-compose.yml`, the hand-rolled `SampleDandiset`, etc.) so we stop re-discovering issues that upstream has already fixed (rabbitmq pin, V3 size, plausibly this race too). When that lands, our local `zarr_format_of` helper can be swapped for upstream's `dandi.tests.test_helpers.zarr_format_of` (currently only on dandi-cli `master`; 1.0.0 was yanked).
